### PR TITLE
store player classes from StoreEncounter as class string instead of class ID

### DIFF
--- a/Details/core/gears.lua
+++ b/Details/core/gears.lua
@@ -1543,13 +1543,12 @@ function _detalhes:StoreEncounter (combat)
 						player_name = player_name .. "-" .. player_realm
 					end
 
-					local _, className = UnitClass (player_name)
-					local class = DetailsFramework.ClassFileNameToIndex[className]
+					local _, class = UnitClass (player_name)
 
 					local damage_actor = damage_container_pool [damage_container_hash [player_name]]
 					if (damage_actor) then
 						local guid = UnitGUID (player_name) or UnitGUID (UnitName ("raid" .. i))
-						this_combat_data.damage [player_name] = {floor (damage_actor.total), (ItemLevelMixIn and ItemLevelMixIn:GetItemLevel(guid)) or _detalhes.item_level_pool [guid] and _detalhes.item_level_pool [guid].ilvl or 0, class or 0}
+						this_combat_data.damage [player_name] = {floor (damage_actor.total), (ItemLevelMixIn and ItemLevelMixIn:GetItemLevel(guid)) or _detalhes.item_level_pool [guid] and _detalhes.item_level_pool [guid].ilvl or 0, class}
 					end
 				elseif (role == "HEALER") then
 					local player_name, player_realm = UnitName ("raid" .. i)
@@ -1557,13 +1556,12 @@ function _detalhes:StoreEncounter (combat)
 						player_name = player_name .. "-" .. player_realm
 					end
 
-					local _, className = UnitClass (player_name)
-					local class = DetailsFramework.ClassFileNameToIndex[className]
+					local _, class = UnitClass (player_name)
 
 					local heal_actor = healing_container_pool [healing_container_hash [player_name]]
 					if (heal_actor) then
 						local guid = UnitGUID (player_name) or UnitGUID (UnitName ("raid" .. i))
-						this_combat_data.healing [player_name] = {floor (heal_actor.total), (ItemLevelMixIn and ItemLevelMixIn:GetItemLevel(guid)) or _detalhes.item_level_pool [guid] and _detalhes.item_level_pool [guid].ilvl or 0, class or 0}
+						this_combat_data.healing [player_name] = {floor (heal_actor.total), (ItemLevelMixIn and ItemLevelMixIn:GetItemLevel(guid)) or _detalhes.item_level_pool [guid] and _detalhes.item_level_pool [guid].ilvl or 0, class}
 					end
 				end
 			end

--- a/Details/core/windows.lua
+++ b/Details/core/windows.lua
@@ -1957,7 +1957,7 @@ local _utf8sub = string.utf8sub
 
 				local sortTable = {}
 				for playerName, t in pairs (playerScore) do
-					local className = _detalhes.classid_to_classstring[t.class or 0]
+					local className = t.class
 					local classColor = "FFFFFFFF"
 					if (className) then
 						classColor = RAID_CLASS_COLORS [className] and RAID_CLASS_COLORS [className].colorStr
@@ -2051,7 +2051,7 @@ local _utf8sub = string.utf8sub
 						tinsert (playerTable, "")
 					end
 
-					local className = _detalhes.classid_to_classstring[player_class[playerTable[1]] or 0]
+					local className = player_class[playerTable[1]]
 					if (className) then
 						local playerNameFormated = _detalhes:GetOnlyName (playerTable[1])
 						local classColor = RAID_CLASS_COLORS [className] and RAID_CLASS_COLORS [className].colorStr


### PR DESCRIPTION
No reason to store players classes as IDs since GetClassInfo doesn't return an ID in wotlk. Removes extra unnecessary steps to restoring encounter data.