### PR TITLE
absorbs are now indexed and sorted based on trinitycore

### DIFF
--- a/Details/core/parser.lua
+++ b/Details/core/parser.lua
@@ -2127,7 +2127,6 @@ function parser:spell_dmg(token, time, who_serial, who_name, who_flags, alvo_ser
 					-- locate buff 
 					for _, applied_absorb in ipairs(escudo[alvo_name]) do 
 						if applied_absorb.serial == who_serial and applied_absorb.spellid == spellid then
-							Details:Msg("Scheduled removal of " .. applied_absorb.spellname .. " from " .. who_name .. " on " .. alvo_name)
 							-- schedule removal of shield buff since absorbed damage is sent after unbuff is called.
 							C_Timer.After(0.1, function() parser:unbuff_shield(alvo_name, who_serial, spellid) end)
 							break

--- a/Details/functions/spells.lua
+++ b/Details/functions/spells.lua
@@ -873,6 +873,58 @@ do
 		[7922]	= true, -- Warbringer
 	}
 
+	_detalhes.MageFireWardSpells = {
+		[543] = 30 , -- Fire Ward (Mage) Rank 1
+		[8457] = 30,
+		[8458] = 30,
+		[10223] = 30,
+		[10225] = 30,
+		[27128] = 30,
+		[43010] = 30, -- Rank 7
+	}
+
+	_detalhes.MageFrostWardSpells = {
+		[6143] = 30, -- Frost Ward (Mage) Rank 1
+		[8461] = 30,
+		[8462] = 30,
+		[10177] = 30,
+		[28609] = 30,
+		[32796] = 30,
+		[43012] = 30, -- Rank 7
+	}
+
+	_detalhes.WarlockShadowWardSpells = {
+		[6229] = 30, -- Shadow Ward (warlock) Rank 1
+		[11739] = 30,
+		[11740] = 30,
+		[28610] = 30,
+		[47890] = 30,
+		[47891] = 30, -- Rank 6
+	}
+
+	_detalhes.MageIceBarrierSpells = {
+		[11426] = 60, -- Ice Barrier (Mage) Rank 1
+		[13031] = 60,
+		[13032] = 60,
+		[13033] = 60,
+		[27134] = 60,
+		[33405] = 60,
+		[43038] = 60,
+		[43039] = 60, -- Rank 8
+	}
+
+	_detalhes.WarlockSacrificeSpells = {
+		[7812] = 30, -- Sacrifice (warlock) Rank 1
+		[19438] = 30,
+		[19440] = 30,
+		[19441] = 30,
+		[19442] = 30,
+		[19443] = 30,
+		[27273] = 30,
+		[47985] = 30,
+		[47986] = 30, -- rank 9
+	}
+
 	_detalhes.AbsorbSpells = {
 		-- Death Knight
 		[48707] = 5, -- Anti-Magic Shell (DK) Rank 1 -- Does not currently seem to show tracable combat log events. It shows energizes which do not reveal the amount of damage absorbed


### PR DESCRIPTION
Copied the sort method from trinitycore for creating a priority of which absorb to use 
https://github.com/TrinityCore/TrinityCore/blob/d81a9e5bc3b3e13b47332b3e7817bd0a0b228cbc/src/server/game/Spells/Auras/SpellAuraEffects.h#L313-L367

also handled frost / shadow / fire ward absorbs properly.

absorbs should now grab the oldest shield (first in first out) same as how trinitycore decides which absorb to use. 

Only tested in solo content so far but it's working as expected.
