### PR TITLE
fix combat loop + GetNumGroupMembers in party

### DIFF
--- a/Details/Libs/DF/fw.lua
+++ b/Details/Libs/DF/fw.lua
@@ -508,7 +508,7 @@ function DF:GroupIterator (func, ...)
 		end
 
 	elseif (IsInGroup()) then
-		for i = 1, GetNumGroupMembers() - 1 do
+		for i = 1, GetNumGroupMembers() do
 			DF:QuickDispatch (func, "party" .. i, ...)
 		end
 

--- a/Details/classes/classe_others.lua
+++ b/Details/classes/classe_others.lua
@@ -1453,7 +1453,7 @@ function _detalhes:CatchRaidBuffUptime (in_or_out)
 		local focus_augmentation = {}
 
 		--party members
-		for groupIndex = 1, _GetNumGroupMembers() - 1 do
+		for groupIndex = 1, _GetNumGroupMembers() do
 			for buffIndex = 1, 41 do
 				local name, _, _, _, _, _, _, unitCaster, _, _, spellid  = _UnitAura ("party"..groupIndex, buffIndex, nil, "HELPFUL")
 				if (name and unitCaster and UnitExists (unitCaster) and UnitExists ("party" .. groupIndex) and UnitIsUnit (unitCaster, "party" .. groupIndex)) then

--- a/Details/compat.lua
+++ b/Details/compat.lua
@@ -23,7 +23,11 @@ function GetNumSubgroupMembers()
 end
 
 function GetNumGroupMembers()
-	return GetNumRaidMembers()
+	if IsInGroup() then
+		return GetNumPartyMembers()
+	else
+		return GetNumRaidMembers()
+	end
 end
 
 --[[

--- a/Details/core/gears.lua
+++ b/Details/core/gears.lua
@@ -9,8 +9,6 @@ local select = select
 local floor = floor
 
 local GetNumGroupMembers = GetNumGroupMembers
-local GetNumRaidMembers = GetNumRaidMembers
-local GetNumPartyMembers = GetNumPartyMembers
 
 local LibGroupInSpecT = LibStub ("LibGroupInSpecT-1.1") --disabled due to classic wow
 
@@ -1849,7 +1847,7 @@ inspect_frame:SetScript ("OnEvent", function (self, event, ...)
 	else
 		if (IsInRaid()) then
 			if (guid and type (guid) == "string") then
-				for i = 1, GetNumRaidMembers() do
+				for i = 1, GetNumGroupMembers() do
 					if (UnitGUID ("raid" .. i) == guid) then
 						ilvl_core:ScheduleTimer ("CalcItemLevel", 2, {"raid" .. i, guid})
 						ilvl_core:ScheduleTimer ("CalcItemLevel", 4, {"raid" .. i, guid})
@@ -1858,7 +1856,7 @@ inspect_frame:SetScript ("OnEvent", function (self, event, ...)
 			end
 		elseif (IsInGroup()) then
 			if (guid and type (guid) == "string") then
-				for i = 1, GetNumPartyMembers() do
+				for i = 1, GetNumGroupMembers() do
 					if (UnitGUID ("party" .. i) == guid) then
 						ilvl_core:ScheduleTimer ("CalcItemLevel", 2, {"party" .. i, guid})
 						ilvl_core:ScheduleTimer ("CalcItemLevel", 4, {"party" .. i, guid})

--- a/Details/core/parser.lua
+++ b/Details/core/parser.lua
@@ -477,7 +477,6 @@ function parser:spell_dmg(token, time, who_serial, who_name, who_flags, alvo_ser
 			((who_flags and _bit_band(who_flags, AFFILIATION_GROUP) ~= 0 and _UnitAffectingCombat(who_name))
 			or (alvo_flags and _bit_band(alvo_flags, AFFILIATION_GROUP) ~= 0 and _UnitAffectingCombat(alvo_name))
 			or (not _detalhes.in_group and who_flags and _bit_band(who_flags, AFFILIATION_GROUP) ~= 0)) then
-
 			_detalhes:EntrarEmCombate(who_serial, who_name, who_flags, alvo_serial, alvo_name, alvo_flags)
 			
 			--> n�o entra em combate se for DOT
@@ -4758,7 +4757,7 @@ function _detalhes:UptadeRaidMembersCache()
 
 	elseif _IsInGroup() then
 		--party
-		for i = 1, _GetNumGroupMembers() - 1 do
+		for i = 1, _GetNumGroupMembers() do
 			local name = _GetUnitName("party"..i, true)
 
 			raid_members_cache[_UnitGUID("party"..i)] = true

--- a/Details/core/util.lua
+++ b/Details/core/util.lua
@@ -881,7 +881,7 @@ function _detalhes:EstaEmCombate()
 			end
 		end
 	elseif _IsInGroup() then
-		for i = 1, _GetNumGroupMembers() - 1, 1 do
+		for i = 1, _GetNumGroupMembers(), 1 do
 			if _UnitAffectingCombat("party"..i) then
 				return true
 			end

--- a/Details_TinyThreat/Details_TinyThreat.lua
+++ b/Details_TinyThreat/Details_TinyThreat.lua
@@ -273,7 +273,7 @@ local function CreatePluginFrames (data)
 				end
 				
 			elseif (_IsInGroup()) then
-				for i = 1, _GetNumGroupMembers() - 1, 1 do
+				for i = 1, _GetNumGroupMembers(), 1 do
 					local thisplayer_name = GetUnitName ("party"..i)
 					local threat_table_index = ThreatMeter.player_list_hash [thisplayer_name]
 					local threat_table = ThreatMeter.player_list_indexes [threat_table_index]


### PR DESCRIPTION
GetNumGroupMembers is used as if it should return the raid size if in a raid, or party size if in a party.

Also removed the `- 1` on `GetNumGroupMembers()` when in a party since `GetNumPartyMembers()` returns only the number of party of members excluding the player.

Fixes https://github.com/Bunny67/Details-WotLK/issues/3