### PR TITLE
improve spec detection, especially for rogues

### DIFF
--- a/Details/Libs/DF/fw.lua
+++ b/Details/Libs/DF/fw.lua
@@ -96,6 +96,10 @@ function DF.GetSpecialization()
 	return specIdx
 end
 
+function DF.GetSpecializationID(class, index)
+	return specIDs[class] and specIDs[class][index]
+end
+
 function DF.GetSpecializationInfoByID (...)
 	if (GetSpecializationInfoByID) then
 		return GetSpecializationInfoByID (...)

--- a/Details/core/gears.lua
+++ b/Details/core/gears.lua
@@ -11,6 +11,7 @@ local floor = floor
 local GetNumGroupMembers = GetNumGroupMembers
 
 local LibGroupInSpecT = LibStub ("LibGroupInSpecT-1.1") --disabled due to classic wow
+local LibGroupTalents = LibStub ("LibGroupTalents-1.0")
 
 local storageDebug = true
 local store_instances = _detalhes.InstancesToStoreData
@@ -2176,7 +2177,32 @@ function _detalhes:LibGroupInSpecT_UpdateReceived (event, guid, unitid, info)
 
 	--print ("LibGroupInSpecT Received from", info.name, info.global_spec_id)
 end
-LibGroupInSpecT.RegisterCallback (_detalhes, "GroupInSpecT_Update", "LibGroupInSpecT_UpdateReceived")
+--LibGroupInSpecT.RegisterCallback (_detalhes, "GroupInSpecT_Update", "LibGroupInSpecT_UpdateReceived")
+
+function _detalhes:LibGroupTalents_Update(event, guid, unit, dominant_tree_id, n1, n2, n3)
+
+	if _detalhes.debug then 
+		_detalhes:Msg("(debug) received LibGroupTalents Update from user", guid)
+	end
+
+	local talent_string = n1.."/"..n2.."/"..n3
+	_detalhes.cached_talents [guid] = talent_string
+	local class, _, _, _, name = select(2, GetPlayerInfoByGUID(guid)) 
+	local specID = DetailsFramework.GetSpecializationID(class, dominant_tree_id) 
+	if specID then 
+		if (not _detalhes.class_specs_coords [specID]) then
+			_detalhes:Msg("(error) Spec ID Invalid: " .. specID .. " for " .. name)
+		else
+			_detalhes.cached_specs [guid] = specID 
+			if _detalhes.debug then 
+				_detalhes:Msg("(debug) saved spec " .. specID .. " for " .. name)
+			end
+		end
+	end
+
+end
+LibGroupTalents.RegisterCallback (_detalhes, "LibGroupTalents_Update")
+
 
 
 --------------------------------------------------------------------------------------------------------------------------------------------

--- a/Details/functions/spells.lua
+++ b/Details/functions/spells.lua
@@ -75,7 +75,10 @@ do
 		[49050] = 254, -- Aimed Shot, Rank 9
 
 		-- Survival Hunter:
---		[] = 255, -- ???
+		[63672] = 255, -- Black Arrow Rank 6
+		[60053] = 255, -- Explosive Shot Rank 4
+		[34503] = 255, -- Expose Weakness Rank 3
+		
 
 		-- Arcane Mage:
 		[12042] = 62, -- Arcane Power
@@ -118,7 +121,8 @@ do
 
 		-- Holy Priest:
 		[48089] = 257, -- Circle of Healing, Rank 7
-		[48072] = 257, -- Prayer of Healing, Rank 7
+		-- prayer is used by disc as well for aoe healing
+		--[48072] = 257, -- Prayer of Healing, Rank 7
 		[47788] = 257, -- Guardian Spirit
 
 		-- Shadow Priest:
@@ -133,15 +137,22 @@ do
 		[1329] = 259, -- Mutilate
 		[5374] = 259, -- Mutilate
 		[27576] = 259, -- Mutilate Off-Hand
-		[51723] = 259, -- Fan of Knives
-		[703] = 259, -- Garrote
-		[1943] = 259, -- Rupture
+		[14177] = 259, -- Cold Blood
+		[51662] = 259, -- Hunger for Blood
 
-		-- Outlaw Rogue:
-		[48668] = 260, -- Run Through, Rank 12
+		-- Combat Rogue:
+		[51690] = 260, -- Killing Spree
+		[13750] = 260, -- Adrenaline Rush
+		[13877] = 260, -- Blade Flurry
+		[14251] = 260, -- Riposte
+
 
 		-- Subtlety Rogue:
-		[48657] = 261, -- Backstab, Rank 12
+		[48660] = 261, -- Hemorrhage rank 5
+		[14183] = 261, -- Premeditation
+		[14185] = 261, -- Preparation
+		[51713] = 261, -- Shadow Dance
+		[14278] = 261, -- Ghostly Strike
 
 		-- Elemental Shaman:
 		[61882] = 262, -- Earthquake


### PR DESCRIPTION
I think LibGroupInspecT might be removable now? Not entirely sure so I left it.

Should be more accurate at getting rogue specs, I've noticed it flip flops between rogues being ass / combat randomly each fight.