### PR TITLE
Fix snake trap and totem elementals.

### DIFF
--- a/Details/classes/container_pets.lua
+++ b/Details/classes/container_pets.lua
@@ -222,13 +222,6 @@ end
 function container_pets:Adicionar (pet_serial, pet_nome, pet_flags, dono_serial, dono_nome, dono_flags)
 
 	if (pet_flags and _bit_band (pet_flags, OBJECT_TYPE_PET) ~= 0 and _bit_band (pet_flags, EM_GRUPO) ~= 0) then
-		-- if the summoner is a pet, just add it to that pets owner. 
-		-- Not sure why pets pet doesn't work right but this will fix Fire ele / earth ele
-		if self.pets [dono_serial] then 
-			local dono = self.pets [dono_serial]
-			self.pets [pet_serial] = {dono[1], dono[2], dono[3], dono[4], dono[5], pet_name, pet_serial}
-			return 
-		end
 		self.pets [pet_serial] = {dono_nome, dono_serial, dono_flags, _detalhes._tempo, true, pet_nome, pet_serial}
 		--if (pet_nome == "Guardian of Ancient Kings") then --remover
 		--	print ("SUMMON", "Adicionou ao container")

--- a/Details/core/parser.lua
+++ b/Details/core/parser.lua
@@ -242,6 +242,10 @@ local sub_pet_ids = {
 		[15438] = true, -- fire elemental
 }
 
+local spell_create_is_summon = {
+	[34600] = true, -- snake trap
+}
+
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 --> internal functions
 
@@ -1160,7 +1164,7 @@ function parser:spell_dmg(token, time, who_serial, who_name, who_flags, alvo_ser
 		end
 
 		-- only treat SPELL_CREATE like SPELL_SUMMON for snake trap.
-		if (token == "SPELL_CREATE" and spellid ~= 34600) then 
+		if (token == "SPELL_CREATE" and not spell_create_is_summon[spellid]) then 
 			return 
 		end
 


### PR DESCRIPTION
fixes #10 and #24  

Unsure if this bug is for 3.3.5 or the core used? I'll assume 3.3.5. 

Essentially when in a group / raid, SPELL_SUMMON is called for the fire elemental, with the totem parent, THEN SPELL_SUMMON is called for the totem. 

This re-calls parser:summon for fire elementals and earth elementals after the totem has been added. 


Snake trap was fixed by hooking SPELL_CREATE to SPELL_SUMMON and only allowing snake_trap through. 