### PR TITLE
Fixes cast tracking for heals (and probably some other casts)

### DIFF
--- a/Details/boot.lua
+++ b/Details/boot.lua
@@ -311,6 +311,7 @@ do
 				["SPELL_INTERRUPT"] = 32,
 				["UNIT_DIED"] = 33,
 				["UNIT_DESTROYED"] = 34,
+				["SPELL_CAST_START"] = 35,
 			}
 
 		--> armazena instancias inativas

--- a/Details/core/parser.lua
+++ b/Details/core/parser.lua
@@ -3572,6 +3572,7 @@ function _detalhes:CaptureDisable(capture_type)
 		token_list["SPELL_PERIODIC_ENERGIZE"] = nil
 	elseif capture_type == "spellcast" then
 		token_list["SPELL_CAST_SUCCESS"] = nil
+		token_list["SPELL_CAST_START"] = nil
 	elseif capture_type == "miscdata" then
 		-- dispell
 		token_list["SPELL_DISPEL"] = nil
@@ -3631,6 +3632,7 @@ function _detalhes:CaptureEnable(capture_type)
 		token_list["SPELL_PERIODIC_ENERGIZE"] = parser.energize
 	elseif capture_type == "spellcast" then
 		token_list["SPELL_CAST_SUCCESS"] = parser.spellcast
+		token_list["SPELL_CAST_START"] = parser.spellcast
 	elseif capture_type == "miscdata" then
 		-- dispell
 		token_list["SPELL_DISPEL"] = parser.dispell
@@ -3713,6 +3715,7 @@ local all_parser_tokens = {
 	["SPELL_PERIODIC_ENERGIZE"] = "energize",
 
 	["SPELL_CAST_SUCCESS"] = "spellcast",
+	["SPELL_CAST_START"] = "spellcast",
 	["SPELL_DISPEL"] = "dispell",
 	["SPELL_STOLEN"] = "dispell",
 	["SPELL_AURA_BROKEN"] = "break_cc",


### PR DESCRIPTION
Seems like SPELL_CAST_XXXX events are super inconsistent in 3.3.5? 

A heal never fires SPELL_CAST_SUCCESS would be the main example I have. 

It seems wherever SPELL_CAST_START is called, there will be no SPELL_CAST_SUCCESS so I think this edit is safe to make.

fixes #17 