### PR TITLE
Track dbm mod using mod.inCombat. 

### DIFF
--- a/Details/Libs/LibDeflate/LibDeflate.lua
+++ b/Details/Libs/LibDeflate/LibDeflate.lua
@@ -3049,7 +3049,7 @@ end
 local _addon_channel_codec
 
 local function GenerateWoWAddonChannelCodec()
-	return LibDeflate:CreateCodec("\000", "\001", "")
+	return LibDeflate:CreateCodec("\000\124", "\001", "")
 end
 
 --- Encode the string to make it ready to be transmitted in World of

--- a/Details/functions/link.lua
+++ b/Details/functions/link.lua
@@ -2598,15 +2598,13 @@
 			local dbm_callback_phase = function (event, msg, ...)
 
 				local mod = _detalhes.encounter_table.DBM_Mod
-
+				
 				if (not mod) then
-					local id = _detalhes:GetEncounterIdFromBossIndex (_detalhes.encounter_table.mapid, _detalhes.encounter_table.id)
-					if (id) then
-						for index, tmod in ipairs (DBM.Mods) do
-							if (tmod.id == id) then
-								_detalhes.encounter_table.DBM_Mod = tmod
-								mod = tmod
-							end
+					for index, tmod in ipairs (DBM.Mods) do
+						if (tmod.inCombat) then
+							_detalhes.encounter_table.DBM_Mod = tmod
+							mod = tmod
+							break
 						end
 					end
 				end

--- a/Details/functions/link.lua
+++ b/Details/functions/link.lua
@@ -2598,7 +2598,7 @@
 			local dbm_callback_phase = function (event, msg, ...)
 
 				local mod = _detalhes.encounter_table.DBM_Mod
-				
+
 				if (not mod) then
 					for index, tmod in ipairs (DBM.Mods) do
 						if (tmod.inCombat) then


### PR DESCRIPTION
WotLK DBM sets mod.inCombat = true on pull, so it's much easier and way more reliable to track the dbm mod this way.

This is still only used by custom DBMs.

Not sure why my pull requests are including extra commits, I'll redo my local repo and see if it fixes it in the future. 