### PR TITLE
Curator wrong CreatureID

### DIFF
--- a/Details/boot.lua
+++ b/Details/boot.lua
@@ -109,7 +109,7 @@ do
 				[15687] = 2, -- Moroes
 				[16457] = 3, -- Maiden of Virtue
 				[1234567890] = 4,
-				[34437] = 5, -- The Curator
+				[15691] = 5, -- The Curator
 				[15688] = 6, -- Terestian Illhoof
 				[16524] = 7, -- Shade of Aran
 				[15689] = 8, -- Netherspite

--- a/Details/functions/raidinfo.lua
+++ b/Details/functions/raidinfo.lua
@@ -274,12 +274,12 @@ do --> data for Karazhan
 
 	-- TODO: Opera
 	local ENCOUNTER_ID_CL = {
-		16152, 15687, 16457, 17535, 34437, 15688, 16524, 15689, 17225, 15690,
+		16152, 15687, 16457, 17535, 15691, 15688, 16524, 15689, 17225, 15690,
 		[16152] = 1, --Attumen the Huntsman
 		[15687] = 2, --Moroes
 		[16457] = 3, --Maiden of Virtue
 		[17535] = 4, --Opera Event
-		[34437] = 5, --The Curator
+		[15691] = 5, --The Curator
 		[15688] = 6, --Terestian Illhoof
 		[16524] = 7, --Shade of Aran
 		[15689] = 8, --Netherspite


### PR DESCRIPTION
Curator had a different Creature ID in details than in Trinitycore and wowhead. 
https://www.wowhead.com/npc=15691/the-curator

The wrong ID doesn't trigger "Combat with boss" so the fight shows up as "Trash Cleanup" in history, and isn't saved properly. 