### PR TITLE
Fix SunderCount plugin

### DIFF
--- a/Details_SunderCount/Details_SunderCount.lua
+++ b/Details_SunderCount/Details_SunderCount.lua
@@ -9,60 +9,59 @@ local sunderCount = {
 	desc = "Shows who uses Sunder Armor.",
 	script_version = 2,
 	script = [[
-		local combat, instance_container, instance = ...
+		local combat, CustomContainer, instance = ...
 		local total, top, amount = 0, 0, 0
 		
 		local spellsToCount = {
-			7386, -- Sunder Armor, shut be same for every expansion
-			20243, -- Devastate Rank 1
-			30016, -- Devastate Rank 2
-			30022, -- Devastate Rank 3
-			47497, -- Devastate Rank 4
+			7386, -- Sunder Armor
+			8647, -- Expose Armor
 			47498, -- Devastate Rank 5
-			8647, -- Expose Armor, shut be same for every expansion
+			47497, -- Devastate Rank 4
+			30022, -- Devastate Rank 3
+			30016, -- Devastate Rank 2
+			20243, -- Devastate Rank 1	
 		}
 
-		for i, actor in ipairs(combat:GetActorList(4)) do
+		for _, actor in ipairs(combat:GetActorList(4)) do
 			if actor:IsPlayer() and actor.spell_cast then
-				for spellName, count in pairs(actor.spell_cast) do
-					for _, spellID in ipairs(spellsToCount) do
-						if spellName == spellID then
-							instance_container:AddValue(actor, count)
+				for spellID, count in pairs(actor.spell_cast) do
+					for _, spell in ipairs(spellsToCount) do
+						if spellID == spell then
+							CustomContainer:AddValue(actor, count)
 						end
 					end
 				end
 			end
 		end
 		
-		total, top = instance_container:GetTotalAndHighestValue()
-		amount = instance_container:GetNumActors()
+		total, top = CustomContainer:GetTotalAndHighestValue()
+		amount = CustomContainer:GetNumActors()
 		
 		return total, top, amount
 	]],
 	tooltip = [[
 		local Actor, Combat, Instance = ...
-		local Format = Details:GetCurrentToKFunction()
 
-		--get the cooltip object(we dont use the convencional GameTooltip here)
 		local GameCooltip = GameCooltip
+		local GetSpellInfo = GetSpellInfo
 		
 		local spellsToCount = {
-			7386, -- Sunder Armor, same for every expansion
-			20243, -- Devastate Rank 1
-			30016, -- Devastate Rank 2
-			30022, -- Devastate Rank 3
-			47497, -- Devastate Rank 4
+			7386, -- Sunder Armor
+			8647, -- Expose Armor
 			47498, -- Devastate Rank 5
-			8647, -- Expose Armor, same for every expansion
+			47497, -- Devastate Rank 4
+			30022, -- Devastate Rank 3
+			30016, -- Devastate Rank 2
+			20243, -- Devastate Rank 1	
 		}
 		
-		local hoveredActorName = Actor.nome
-		for i, actor in ipairs(Combat:GetActorList(4)) do
-			if actor:IsPlayer() and actor.nome == hoveredActorName and actor.spell_cast then
-				for _, spellID in ipairs(spellsToCount) do
-					for spellName, count in pairs(actor.spell_cast) do
-						if spellName == spellID then
-							local localizedSpellName, _, Icon = GetSpellInfo(spellID)
+		local Owner = Actor.nome
+		for _, actor in ipairs(Combat:GetActorList(4)) do
+			if actor:IsPlayer() and actor.nome == Owner and actor.spell_cast then
+				for spellID, count in pairs(actor.spell_cast) do
+					for _, spell in ipairs(spellsToCount) do
+						if spellID == spell then
+							local localizedSpellName, _, Icon = GetSpellInfo(spell)
 							GameCooltip:AddLine(localizedSpellName, count)
 							Details:AddTooltipBackgroundStatusbar()
 							GameCooltip:AddIcon(Icon, 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)

--- a/Details_SunderCount/Details_SunderCount.lua
+++ b/Details_SunderCount/Details_SunderCount.lua
@@ -5,29 +5,72 @@ local sunderCount = {
 	attribute = false,
 	spellid = false,
 	target = false,
-	author = "Matz",
+	author = "NoM0Re",
 	desc = "Shows who uses Sunder Armor.",
 	script_version = 2,
 	script = [[
-		local combat, container, instance = ...
+		local combat, instance_container, instance = ...
 		local total, top, amount = 0, 0, 0
+		
+		local spellsToCount = {
+			7386, -- Sunder Armor, shut be same for every expansion
+			20243, -- Devastate Rank 1
+			30016, -- Devastate Rank 2
+			30022, -- Devastate Rank 3
+			47497, -- Devastate Rank 4
+			47498, -- Devastate Rank 5
+			8647, -- Expose Armor, shut be same for every expansion
+		}
 
-		local sunderName = GetSpellInfo(11597)
-		local actors = combat:GetActorList(DETAILS_ATTRIBUTE_MISC)
-		for i, actor in ipairs(actors) do
+		for i, actor in ipairs(combat:GetActorList(4)) do
 			if actor:IsPlayer() and actor.spell_cast then
 				for spellName, count in pairs(actor.spell_cast) do
-					if spellName == sunderName then
-						container:AddValue(actor, count)
+					for _, spellID in ipairs(spellsToCount) do
+						if spellName == spellID then
+							instance_container:AddValue(actor, count)
+						end
 					end
 				end
 			end
 		end
-
-		total, top = container:GetTotalAndHighestValue()
-		amount = container:GetNumActors()
-
+		
+		total, top = instance_container:GetTotalAndHighestValue()
+		amount = instance_container:GetNumActors()
+		
 		return total, top, amount
+	]],
+	tooltip = [[
+		local Actor, Combat, Instance = ...
+		local Format = Details:GetCurrentToKFunction()
+
+		--get the cooltip object(we dont use the convencional GameTooltip here)
+		local GameCooltip = GameCooltip
+		
+		local spellsToCount = {
+			7386, -- Sunder Armor, same for every expansion
+			20243, -- Devastate Rank 1
+			30016, -- Devastate Rank 2
+			30022, -- Devastate Rank 3
+			47497, -- Devastate Rank 4
+			47498, -- Devastate Rank 5
+			8647, -- Expose Armor, same for every expansion
+		}
+		
+		local hoveredActorName = Actor.nome
+		for i, actor in ipairs(Combat:GetActorList(4)) do
+			if actor:IsPlayer() and actor.nome == hoveredActorName and actor.spell_cast then
+				for _, spellID in ipairs(spellsToCount) do
+					for spellName, count in pairs(actor.spell_cast) do
+						if spellName == spellID then
+							local localizedSpellName, _, Icon = GetSpellInfo(spellID)
+							GameCooltip:AddLine(localizedSpellName, count)
+							Details:AddTooltipBackgroundStatusbar()
+							GameCooltip:AddIcon(Icon, 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
+						end
+					end
+				end
+			end
+		end
 	]],
 	total_script = [[
 		local value, top, total, combat, instance = ...
@@ -37,8 +80,6 @@ local sunderCount = {
 		local value, top, total, combat, instance = ...
 		return string.format("%.1f", value / total * 100)
 	]],
-	tooltip = false,
-	notooltip = true,
 }
 
 Details:InstallCustomObject(sunderCount)


### PR DESCRIPTION
Closes #12 -2

The Base Plugin never worked, i fixed it from the ground off.
Feel free to blame the code. 🔢 

How to test this PR:

1. [Download this](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2FNoM0Re%2FDetails-WotLK%2Ftree%2Fmaster%2FDetails_SunderCount)

2. Unzip and put it in ```Interface/Addons/Details_SunderCount``` Folder.

3. Activate ```Details!: SunderCount (plugin)``` in Addons (Ingame)

3. Ingame do these Steps:
![Unbenannt](https://github.com/Bunny67/Details-WotLK/assets/1629787/6cd1aaa1-4431-432f-b1cc-b47871f6d6e8)

4. Reload with ```/rl```